### PR TITLE
Check for options.{read,resolve} in load, load.file, and load.string

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,31 +26,31 @@ Loads all dependencies of the Jade AST. `load.string` and `load.file` are syntac
 
 - `lex` (function): **(required)** the lexer used
 - `parse` (function): **(required)** the parser used
-- `resolve` (function): a function used to override `load.resolve`. Defaults to undefined, i.e. `load.resolve` is used.
-- `read` (function): a function used to override `load.resolve`. Defaults to undefined, i.e. `load.read` is used.
+- `resolve` (function): a function used to override `load.resolve`. Defaults to `load.resolve`.
+- `read` (function): a function used to override `load.read`. Defaults to `load.read`.
 - `basedir` (string): the base directory of absolute inclusion. This is **required** when absolute inclusion (file name starts with `'/'`) is used. Defaults to undefined.
 
-The `options` object is passed to `load.resolve` and `load.read`.
+The `options` object is passed to `load.resolve` and `load.read`, or equivalently `options.resolve` and `options.read`.
 
 ### `load.resolve(filename, source, options)`
 
-Callback used by `jade-load` to resolve the full path of an included or extended file given the path of the source file. If `options` contain a `resolve` property, then that function is called and its results returned.
-
-This function is not meant to be called from outside of `jade-load`, but rather for you to override.
+Callback used by `jade-load` to resolve the full path of an included or extended file given the path of the source file.
 
 `filename` is the included file. `source` is the name of the parent file that includes `filename`.
 
+This function is not meant to be called from outside of `jade-load`, but rather for you to override.
+
 ### `load.read(filename, options)`
 
-Callback used by `jade-load` to return the contents of a file. If `options` contain a `read` property, then that function is called and its results returned instead of this function.
-
-This function is not meant to be called from outside of `jade-load`, but rather for you to override.
+Callback used by `jade-load` to return the contents of a file.
 
 `filename` is the file to read.
 
+This function is not meant to be called from outside of `jade-load`, but rather for you to override.
+
 ### `load.validateOptions(options)`
 
-Callback used `jade-load` to ensure the options object is valid. If your overriden `load.resolve` or `load.read` use a different `options` schema, you will need to override this function as well.
+Callback used `jade-load` to ensure the options object is valid. If your overriden `load.resolve` or `load.read` uses a different `options` scheme, you will need to override this function as well.
 
 This function is not meant to be called from outside of `jade-load`, but rather for you to override.
 

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ function load(ast, options) {
         }
         var path, str;
         try {
-          path = load.resolve(file.path, file.filename, options);
+          path = (options.resolve || load.resolve)(file.path, file.filename, options);
           file.fullPath = path;
-          str = load.read(path, options);
+          str = (options.read || load.read)(path, options);
         } catch (ex) {
           ex.message += '\n    at ' + node.filename + ' line ' + node.line;
           throw ex;
@@ -42,12 +42,11 @@ load.string = function loadString(str, filename, options) {
 };
 load.file = function loadFile(filename, options) {
   load.validateOptions(options);
-  var str = load.read(filename, options);
+  var str = (options.read || load.read)(filename, options);
   return load.string(str, filename, options);
 }
 
 load.resolve = function resolve(filename, source, options) {
-  if (options && options.resolve) return options.resolve(filename, source, options);
   filename = filename.trim();
   source = source.trim();
   if (filename[0] !== '/' && !source)
@@ -63,11 +62,13 @@ load.resolve = function resolve(filename, source, options) {
   return filename;
 };
 load.read = function read(filename, options) {
-  if (options && options.read) return options.read(filename, options);
   return fs.readFileSync(filename, 'utf8');
 };
 
 load.validateOptions = function validateOptions(options) {
+  if (typeof options !== 'object') {
+    throw new TypeError('options must be an object');
+  }
   if (typeof options.lex !== 'function') {
     throw new TypeError('options.lex must be a function');
   }


### PR DESCRIPTION
Invoking `options.read` from `load.read` is counter-intuitive, and makes it more complicated for users who overrode `load.read` to again override it once.
