### PR TITLE
Fixed load.file and load.string documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ var load = require('jade-load');
 ```
 
 ### `load(ast, options)`
-### `load.string(str, options)`
-### `load.file(file, options)`
+### `load.string(str, filename, options)`
+### `load.file(filename, options)`
 
 Loads all dependencies of the Jade AST. `load.string` and `load.file` are syntactic sugar that parses the string or file instead of you doing it yourself.
 


### PR DESCRIPTION
I was playing around with the Jade internals and noticed that the `filename` parameter was missing from the load.string documentation in README.md, so I fixed that. Also renamed the `file` parameter in the documentation for load.file to `filename` to be more consistent with both the source and the rest of the README.
